### PR TITLE
Mention remark-frontmatter in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ This [remark](https://github.com/wooorm/remark) plugin takes markdown with yaml 
 ```javascript
 const unified = require('unified')
 const markdown = require('remark-parse')
-const taskListPlugin = require('remark-parse-yaml');
+const frontmatter = require('remark-frontmatter')
+const parseFrontmatter = require('remark-parse-yaml');
 
 let processor = unified()
-    .use(markdown, { gfm: true, footnotes: true, yaml: true })
-    .use(yamlPlugin)
+    .use(markdown)
+    .use(frontmatter)
+    .use(parseFrontmatter)
 ```
 
 When the processor is run, `yaml` nodes will now have an additional key, `parsedValue`, 


### PR DESCRIPTION
Since https://github.com/remarkjs/remark/commit/8fc10f2821792d81a6d1428046453689ab00d69c frontmatter is no longer a part of markdown-parser core. Adding remark-frontmatter helps.