### PR TITLE
Upgrade js-yaml to remove security notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remark-parse-yaml",
   "description": "Parses yaml blocks into structured data",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "keywords": [
     "remark",
     "remark-plugin",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "js-yaml": "^3.9.0",
+    "js-yaml": "^3.13.1",
     "unist-util-map": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I have been visited by the spirit of GitHub Security Notices on a project that's using `remark-parse-yaml`. I've upgraded the `js-yaml` dependency to the latest version so we get rid of the notice. 